### PR TITLE
Made some changes to pyaio that you might think are intresting

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,23 +5,37 @@ Version 0.2
 Working on Linux only
 
 Reading
+    aio_read(fileno, file-offset, length, callback)
 
 ```python
 import pyaio
+import os
 	
-def aio_callback(buf):
-    print 'python callback %s' % buf
-	
-pyaio.aio_read('/tmp/pyaio.txt', 10, 20, aio_callback)
+def aio_callback(buf, rcode, errno):
+    if rcode > 0:
+        print 'python callback %s' % buf
+    elif rcode == 0:
+        print "EOF"
+    else:
+        print "Error: %d" % errno
+        
+fd = os.open('/tmp/pyaio.txt', os.O_RDONLY)
+pyaio.aio_read(fd, 10, 20, aio_callback)
 ```
 
 Writing
+    aio_write(fileno, buffer-object, file-offset, callback)
 
 ```python
 import pyaio
+import os
 
-def aio_callback():
-    print 'done writing!'
+def aio_callback(rt, errno):
+    if rt > 0:
+        print "Wrote %d bytes" % rt
+    else:
+        print "Got error: %d" % errno
 
-pyaio.aio_write('/tmp/pyaio.txt', "Writing Test.......", 30, 15, aio_callback)
+fd = os.open('/tmp/pyaio.txt', os.O_WRONLY)
+pyaio.aio_write(fd, "Writing Test.......", 30, aio_callback)
 ```

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,14 @@ from distutils.core import setup, Extension
 version = '0.2'
 
 mymodule = \
-    Extension('pyaio', 
-    sources = ['pyaio/pyaio.c'], 
+    Extension('pyaio',
+    sources = ['pyaio/pyaio.c'],
     libraries = ['rt'],
+    extra_compile_args = ['-D_FILE_OFFSET_BITS=64'],
     define_macros=[('PYAIO_VERSION', '"{0}"'.format(version))])
 
 setup(
-    name = 'pyaio', 
+    name = 'pyaio',
     version = '0.2',
     description = 'Python Asynchronous I/O bindings (aio.h)',
     author = 'Felipe Cruz',

--- a/tests/test_pyaio.py
+++ b/tests/test_pyaio.py
@@ -1,44 +1,79 @@
 import pyaio
 import time
+import os
 
 def test_aio_read():
-    def callback(buf):
+    def callback(buf, rt, er):
         assert buf == "#include <Python.h>\n"
+        assert rt == len(buf)
+        assert er == 0
 
-    ret = pyaio.aio_read("./pyaio/pyaio.c", 0, 20, callback)
+    fileno = os.open('./pyaio/pyaio.c', os.O_RDONLY)
+    ret = pyaio.aio_read(fileno, 0, 20, callback)
     assert ret == 0
-
-def test_aio_read_stress():
-    def callback(buf):
-        assert buf == "#include <Python.h>\n"
-
-    for x in range(1000):
-        ret = pyaio.aio_read("./pyaio/pyaio.c", 0, 20, callback)
-        assert ret == 0
-
     time.sleep(0.2)
 
+def test_aio_read_stress():
+    def callback(buf, rt, er):
+        assert buf == "#include <Python.h>\n"
+        assert rt == len(buf)
+        assert er == 0
+
+    fileno = os.open('./pyaio/pyaio.c', os.O_RDONLY)
+    for x in range(1000):
+        ret = pyaio.aio_read(fileno, 0, 20, callback)
+        time.sleep(0.001)
+        assert ret == 0
+
+    time.sleep(0.3)
+
 def test_aio_write():
-    def callback2():
+    def callback2(rt, er):
+        assert rt == 10
+        assert er == 0
         f = file('/tmp/c.txt', 'r')
         content = f.read()
         assert content == "pyaiopyaio"
 
-    ret = pyaio.aio_write("/tmp/c.txt", "pyaiopyaio", 0, 10, callback2)
+    fileno = os.open('/tmp/c.txt', os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+    ret = pyaio.aio_write(fileno, "pyaiopyaio", 0, callback2)
     assert ret == 0
+    time.sleep(0.2)
 
 def test_aio_write_read_stress():
-    def callback2():
-        pass
+    def callback2(rt, er):
+        assert rt == 10
+        assert er == 0
 
-    def callback(buf):
-        assert buf == "pyaiopyaio"
+    def callback(buf, rt, er):
+        if rt > 0:
+            assert len(buf) == rt
+        else:
+            # EOF
+            assert rt == 0
+        assert er == 0
 
+
+    fileno = os.open('/tmp/c.txt', os.O_RDWR | os.O_CREAT | os.O_TRUNC)
+    # These could hit in any order so its not safe to say the
     for x in range(1000):
-        ret = pyaio.aio_write("/tmp/c.txt", 
-                              "pyaiopyaio", x * 10, 10, callback2)
-        ret = pyaio.aio_read("/tmp/c.txt",  x * 10, 10, callback)
-
+        ret = pyaio.aio_write(fileno,
+                              "pyaiopyaio", x * 10, callback2)
+        time.sleep(0.001)
+        ret = pyaio.aio_read(fileno,  x * 10, 10, callback)
+        time.sleep(0.001)
     assert ret == 0
     time.sleep(0.3)
 
+def run(method):
+    ts = time.time()
+    print "Running %s" % method.__name__
+    method()
+    print "Passed!"
+    print "Total Time (%.2f)." % (time.time() - ts)
+
+if __name__ == '__main__':
+    run(test_aio_read)
+    run(test_aio_write)
+    run(test_aio_read_stress)
+    run(test_aio_write_read_stress)


### PR DESCRIPTION
Allowed write to accept a read view buffer object instead of just strings
Removed some double copying that was taking place.
Made use of Real-time signals, there is a limit to the queue size
though. [RTMIN+10,RTMIN+11]
Removed the number of bytes from the write because it can be derived
from the buffer view.
Increased the file offset to unsigned 64bit int for large files
Added return code and errorno to the callback arguments so we can
actually instrument pyaio into some event library like gevent
Added sleeps in the stress test because of the maximum signal queue size

I will be wrapping this in gevent. 
